### PR TITLE
Tiny README update

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ useControl(name: string, {
   items: string[];
 
   // button
-  onPress(): void;
+  onClick(): void;
 
   // custom
   component?: React.Component;


### PR DESCRIPTION
- revised the README documentation example to use the accurate `onClick` name instead of `onPress`.