### PR TITLE
Add "default closed groups" prop

### DIFF
--- a/src/Controls.tsx
+++ b/src/Controls.tsx
@@ -53,7 +53,11 @@ const groupByGroup = (items: any): any => {
   }, {} as { [key: string]: any });
 }
 
-export const Controls = React.memo(() => {
+interface ControlsProps {
+  defaultClosedGroups?: string[]
+}
+
+export const Controls = React.memo((props?: ControlsProps) => {
   const [{ pos }, setPos] = useSpring(() => ({ pos: [0, 0] }));
   const bind = useDrag(({ movement, memo = ((pos as any).getValue ? (pos as any).getValue() : (pos as any).get()) }) => {
     setPos({
@@ -73,6 +77,12 @@ export const Controls = React.memo(() => {
     };
   }, []);
 
+  const getGroupConfig = (groupName: string): any => {
+    return {
+      defaultClosed: props?.defaultClosedGroups?.includes(groupName) ?? false
+    }
+  }
+
   return (
     <Float
       style={{
@@ -85,7 +95,7 @@ export const Controls = React.memo(() => {
       <Header {...bind()} />
       <Items>
         {Object.entries(groupByGroup(controls)).map(([groupName, items]: any) => (
-          <ControlGroup key={groupName} title={groupName} controls={items} />
+          <ControlGroup key={groupName} title={groupName} controls={items} config={getGroupConfig(groupName)} />
         ))}
       </Items>
     </Float>

--- a/src/components/ControlGroup.tsx
+++ b/src/components/ControlGroup.tsx
@@ -39,8 +39,8 @@ const Container = styled.div<{ open: boolean, bg: boolean }>`
   margin-bottom: 8px;
 `;
 
-export const ControlGroup = ({ title, controls }: any) => {
-  const [open, setOpen] = useState(true);
+export const ControlGroup = ({ title, controls, config }: any) => {
+  const [open, setOpen] = useState(!config.defaultClosed ?? true);
   const isDefault = title !== 'DEFAULT_GROUP';
   return (
     <div>


### PR DESCRIPTION
Adds an optional `defaultClosedGroups` string array prop to the root `<Control />` element. When set, any groups named in the array will show as closed on first draw.

**Example**

```
const a = useControl('First Setting', { type: 'boolean'})
const b = useControl('Second Setting', { type: 'boolean', group: 'GroupA' })
const c = useControl('Third Setting', { type: 'boolean', group: 'GroupB' })

return <Control defaultClosedGroups={['GroupB']} />
```

Settings list `GroupB` would then be collapsed on first draw.

**Note**

Using this library a lot lately (thank you!) and could really use the option for some of my longer control lists. Understood if this is not ideal because it's a rogue prop on the top-level component. Betting that this is preferred to polluting the `useControl` hook, but happy to do a version with it there instead if I was wrong.